### PR TITLE
docs: document 1000 entry limit for --all flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ CONTROLS:\n  \
     Enter       Restore to selected commit\n  \
     q/Esc       Quit")]
 struct Cli {
-    /// Show all reflog entries (default: last 50)
+    /// Show all reflog entries (max 1000, default: last 50)
     #[arg(short, long)]
     all: bool,
 }


### PR DESCRIPTION
Fixes #1

The `--all` flag was silently capping at 1000 entries without documenting this limit. Updated the help text to clarify that `--all` shows max 1000 entries.

**Changes:**
- Updated CLI help text to mention the 1000 entry limit