### PR TITLE
perf: pull selected_index() out of map closure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -383,12 +383,12 @@ fn ui(f: &mut Frame, app: &mut App) {
         .split(chunks[1]);
 
     // Timeline list
+    let selected_idx = app.selected_index();
     let items: Vec<ListItem> = app
         .entries
         .iter()
         .enumerate()
         .map(|(i, entry)| {
-            let selected_idx = app.selected_index();
             let is_selected = i == selected_idx;
             let style = if is_selected {
                 Style::default().bg(Color::DarkGray).fg(Color::Yellow).add_modifier(Modifier::BOLD)


### PR DESCRIPTION
Fixes #3

Moved `selected_index()` call outside the map iterator to avoid calling it N times (once per list item).

**Changes:**
- Pulled `selected_index()` out before the iterator in `ui()` function
- Micro-optimization that improves code efficiency