### PR TITLE
Fix Windows arrow key navigation skipping rows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -219,6 +219,11 @@ fn run_app<B: ratatui::backend::Backend>(
         terminal.draw(|f| ui(f, app))?;
 
         if let Event::Key(key) = event::read()? {
+            // Only handle key press events, ignore key release to prevent double-triggering on Windows
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+
             if app.show_confirmation {
                 match key.code {
                     KeyCode::Char('y') | KeyCode::Char('Y') => {


### PR DESCRIPTION
## Description
Fixes the arrow key navigation issue on Windows where pressing arrow keys (or j/k) would skip entries in the timeline.

## Root Cause
On Windows, crossterm fires both `KeyEventKind::Press` and `KeyEventKind::Release` events for each key press. The previous code was handling both events, causing the navigation to advance twice per key press.

## Solution
Added a filter to only process `KeyEventKind::Press` events and ignore `KeyEventKind::Release` events. This ensures each key press only triggers one navigation action.

## Changes
- Added `KeyEventKind` import from crossterm
- Added event kind check in `run_app()` to filter out key release events
- This fix applies to all keyboard inputs, not just arrow keys

## Testing
- Code compiles successfully with `cargo check`
- Fix follows the standard pattern used in crossterm/ratatui applications for cross-platform compatibility

Fixes #7
