### PR TITLE
feat(cli): export timeline as JSON (#13)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 [dependencies]
 ratatui = "0.29"
 crossterm = "0.28"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ crossterm = "0.28"
 chrono = "0.4"
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,12 +1,14 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use std::process::Command;
+use serde::Serialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GitEntry {
     pub hash: String,
     pub message: String,
     pub timestamp: DateTime<Utc>,
+    pub author: String,
     pub relative_time: String,
 }
 
@@ -40,7 +42,7 @@ impl GitManager {
             .current_dir(&self.repo_path)
             .args([
                 "reflog",
-                "--format=%H%x00%s%x00%ct",
+                "--format=%H%x00%s%x00%ct%x00%an",
                 &format!("-n{}", limit),
             ])
             .output()
@@ -54,11 +56,12 @@ impl GitManager {
         let mut entries = Vec::new();
 
         for line in reflog_output.lines() {
-            let parts: Vec<&str> = line.splitn(3, '\x00').collect();
-            if parts.len() >= 3 {
+            let parts: Vec<&str> = line.splitn(4, '\x00').collect();
+            if parts.len() >= 4 {
                 let hash = parts[0].to_string();
                 let message = parts[1].to_string();
                 let timestamp_str = parts[2];
+                let author = parts[3].to_string();
 
                 if let Ok(timestamp_secs) = timestamp_str.parse::<i64>() {
                     let timestamp = DateTime::from_timestamp(timestamp_secs, 0)
@@ -69,6 +72,7 @@ impl GitManager {
                         hash,
                         message,
                         timestamp,
+                        author,
                         relative_time,
                     });
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use serde_json;
 use clap::Parser;
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
@@ -23,7 +24,8 @@ use git::{GitEntry, GitManager};
 #[command(about = "🕰️  Undo ANY git mistake in 3 seconds", long_about = None)]
 #[command(after_help = "EXAMPLES:\n  \
     git-time-machine              # Show last 50 reflog entries\n  \
-    git-time-machine --all        # Show all reflog entries\n\n\
+    git-time-machine --all        # Show all reflog entries\n  \
+    git-time-machine --export-json # Export as JSON for automation\n\n\
 CONTROLS:\n  \
     ↑/k, ↓/j    Navigate up/down\n  \
     Home/End    Jump to first/last entry\n  \
@@ -35,6 +37,10 @@ struct Cli {
     /// Show all reflog entries (max 1000, default: last 50)
     #[arg(short, long)]
     all: bool,
+
+    /// Export reflog timeline as JSON
+    #[arg(long)]
+    export_json: bool,
 }
 
 struct App {
@@ -170,6 +176,13 @@ impl App {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     
+    if cli.export_json {
+        let git_manager = GitManager::new()?;
+        let entries = git_manager.get_reflog_entries(cli.all)?;
+        println!("{}", serde_json::to_string_pretty(&entries)?);
+        return Ok(());
+    }
+
     // Setup panic hook to restore terminal
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use git::{GitEntry, GitManager};
 
 #[derive(Parser)]
 #[command(name = "git-time-machine")]
-#[command(about = "🕰️  Undo ANY git mistake in 3 seconds", long_about = None)]
+#[command(about = "🕰️  Undo DISASTROUS git mistakes in 3 seconds", long_about = None)]
 #[command(after_help = "EXAMPLES:\n  \
     git-time-machine              # Show last 50 reflog entries\n  \
     git-time-machine --all        # Show all reflog entries\n  \


### PR DESCRIPTION
- Closes #13 
### Summary of changes

1. Added `--export-json` CLI flag to export reflog entries in structured JSON format
2. Updated `GitEntry` to include `author` information and support `serde` serialization
3. Configured the application to print JSON to stdout and exit early when the export flag is present bypassing the TUI