### PR TITLE
feat: add vim-style gg/G navigation

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -142,6 +142,30 @@ impl GitManager {
         }
     }
 
+    pub fn get_full_diff(&self, commit_hash: &str) -> Result<String> {
+        if !commit_hash.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Ok("Invalid commit hash format".to_string());
+        }
+
+        let output = Command::new("git")
+            .current_dir(&self.repo_path)
+            .args(["show", "--no-color", commit_hash])
+            .output()
+            .context("Failed to get full diff")?;
+
+        if !output.status.success() {
+            let error = String::from_utf8_lossy(&output.stderr);
+            return Ok(format!("Error getting diff: {}", error));
+        }
+
+        let diff_output = String::from_utf8(output.stdout)?;
+        if diff_output.trim().is_empty() {
+            Ok("No diff available.".to_string())
+        } else {
+            Ok(diff_output)
+        }
+    }
+
     fn format_relative_time(timestamp: &DateTime<Utc>) -> String {
         let now = Utc::now();
         let duration = now.signed_duration_since(*timestamp);

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use git::{GitEntry, GitManager};
 CONTROLS:\n  \
     ↑/k, ↓/j    Navigate up/down\n  \
     Home/End    Jump to first/last entry\n  \
+    gg/G        Jump to first/last entry (vim-style)\n  \
     PgUp/PgDn   Jump 10 entries\n  \
     Space       Toggle diff panel\n  \
     d           Switch between diff summary and full diff\n  \
@@ -70,6 +71,7 @@ struct App {
     filtered_entries: Vec<usize>,
     search_active: bool,
     show_absolute_time: bool,
+    last_key_was_g: bool,
 }
 
 impl App {
@@ -102,6 +104,7 @@ impl App {
             filtered_entries,
             search_active: false,
             show_absolute_time: false,
+            last_key_was_g: false,
         })
     }
 
@@ -427,6 +430,23 @@ fn run_app<B: ratatui::backend::Backend>(
                             app.update_diff_if_visible()?;
                         }
                     }
+                    KeyCode::Char('g') => {
+                        if app.last_key_was_g && !app.filtered_entries.is_empty() {
+                            app.list_state.select(Some(0));
+                            app.update_diff_if_visible()?;
+                            app.last_key_was_g = false;
+                        } else {
+                            app.last_key_was_g = true;
+                        }
+                        continue;
+                    }
+                    KeyCode::Char('G') => {
+                        if !app.filtered_entries.is_empty() {
+                            let last = app.filtered_entries.len() - 1;
+                            app.list_state.select(Some(last));
+                            app.update_diff_if_visible()?;
+                        }
+                    }
                     KeyCode::PageDown => {
                         if !app.filtered_entries.is_empty() {
                             let current = app.list_state.selected().unwrap_or(0);
@@ -459,6 +479,7 @@ fn run_app<B: ratatui::backend::Backend>(
                     }
                     _ => {}
                 }
+                app.last_key_was_g = false;
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
+    event::{self, Event, KeyCode, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -30,7 +30,14 @@ CONTROLS:\n  \
     PgUp/PgDn   Jump 10 entries\n  \
     Space       Toggle diff preview\n  \
     Enter       Restore to selected commit\n  \
-    q/Esc       Quit")]
+    /           Search/filter commits by message\n  \
+    Esc         Clear active filter (or quit if no filter)\n  \
+    q           Quit\n\n\
+SEARCH MODE:\n  \
+    type        Filter commits (case-insensitive, multi-word AND)\n  \
+    Enter       Apply filter and return to navigation\n  \
+    Esc         Cancel search and clear filter\n  \
+    Backspace   Delete last character")]
 struct Cli {
     /// Show all reflog entries (max 1000, default: last 50)
     #[arg(short, long)]
@@ -47,6 +54,10 @@ struct App {
     diff_scroll_offset: u16,
     diff_visible_height: u16,
     has_uncommitted_changes: bool,
+    search_mode: bool,
+    search_query: String,
+    filtered_entries: Vec<usize>,
+    search_active: bool,
 }
 
 impl App {
@@ -60,6 +71,8 @@ impl App {
             list_state.select(Some(0));
         }
 
+        let filtered_entries = (0..entries.len()).collect();
+
         Ok(Self {
             git_manager,
             entries,
@@ -70,6 +83,10 @@ impl App {
             diff_scroll_offset: 0,
             diff_visible_height: 10,
             has_uncommitted_changes,
+            search_mode: false,
+            search_query: String::new(),
+            filtered_entries,
+            search_active: false,
         })
     }
 
@@ -77,24 +94,69 @@ impl App {
         self.list_state.selected().unwrap_or(0)
     }
 
+    fn selected_entry_idx(&self) -> Option<usize> {
+        let sel = self.list_state.selected()?;
+        self.filtered_entries.get(sel).copied()
+    }
+
+    fn update_filter(&mut self) {
+        let query_lower = self.search_query.to_lowercase();
+        let tokens: Vec<&str> = query_lower.split_whitespace().collect();
+        if tokens.is_empty() {
+            self.filtered_entries = (0..self.entries.len()).collect();
+        } else {
+            self.filtered_entries = self
+                .entries
+                .iter()
+                .enumerate()
+                .filter(|(_, e)| {
+                    let msg = e.message.to_lowercase();
+                    tokens.iter().all(|t| msg.contains(t))
+                })
+                .map(|(i, _)| i)
+                .collect();
+        }
+        if self.filtered_entries.is_empty() {
+            self.list_state.select(None);
+        } else {
+            let sel = self.list_state.selected().unwrap_or(0);
+            if sel >= self.filtered_entries.len() {
+                self.list_state.select(Some(self.filtered_entries.len() - 1));
+            } else if self.list_state.selected().is_none() {
+                self.list_state.select(Some(0));
+            }
+        }
+    }
+
+    fn clear_filter(&mut self) {
+        self.search_query.clear();
+        self.search_active = false;
+        self.search_mode = false;
+        self.filtered_entries = (0..self.entries.len()).collect();
+        if !self.entries.is_empty() {
+            self.list_state.select(Some(0));
+        }
+    }
+
     fn update_diff_if_visible(&mut self) -> Result<()> {
         if self.show_diff {
-            let idx = self.selected_index();
-            if let Some(entry) = self.entries.get(idx) {
-                self.diff_content = self.git_manager.get_diff_stat(&entry.hash)?;
-                self.diff_scroll_offset = 0;
+            if let Some(idx) = self.selected_entry_idx() {
+                if let Some(entry) = self.entries.get(idx) {
+                    self.diff_content = self.git_manager.get_diff_stat(&entry.hash)?;
+                    self.diff_scroll_offset = 0;
+                }
             }
         }
         Ok(())
     }
 
     fn next(&mut self) -> Result<()> {
-        if self.entries.is_empty() {
+        if self.filtered_entries.is_empty() {
             return Ok(());
         }
         let i = match self.list_state.selected() {
             Some(i) => {
-                if i >= self.entries.len() - 1 {
+                if i >= self.filtered_entries.len() - 1 {
                     i // Clamp at bottom instead of wrap-around
                 } else {
                     i + 1
@@ -108,7 +170,7 @@ impl App {
     }
 
     fn previous(&mut self) -> Result<()> {
-        if self.entries.is_empty() {
+        if self.filtered_entries.is_empty() {
             return Ok(());
         }
         let i = match self.list_state.selected() {
@@ -129,9 +191,10 @@ impl App {
     fn toggle_diff(&mut self) -> Result<()> {
         self.show_diff = !self.show_diff;
         if self.show_diff {
-            let idx = self.selected_index();
-            if let Some(entry) = self.entries.get(idx) {
-                self.diff_content = self.git_manager.get_diff_stat(&entry.hash)?;
+            if let Some(idx) = self.selected_entry_idx() {
+                if let Some(entry) = self.entries.get(idx) {
+                    self.diff_content = self.git_manager.get_diff_stat(&entry.hash)?;
+                }
             }
         }
         self.diff_scroll_offset = 0;
@@ -157,7 +220,9 @@ impl App {
     }
 
     fn restore_selected(&self) -> Result<Option<(String, String)>> {
-        let idx = self.list_state.selected().unwrap_or(0);
+        let Some(idx) = self.selected_entry_idx() else {
+            return Ok(None);
+        };
         if let Some(entry) = self.entries.get(idx) {
             self.git_manager.restore_to_commit(&entry.hash)?;
             Ok(Some((entry.hash[..7].to_string(), entry.message.clone())))
@@ -174,14 +239,14 @@ fn main() -> Result<()> {
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
         let _ = disable_raw_mode();
-        let _ = execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture);
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
         original_hook(panic_info);
     }));
     
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    execute!(stdout, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -191,11 +256,7 @@ fn main() -> Result<()> {
 
     // Restore terminal
     disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
 
     match res {
@@ -224,6 +285,37 @@ fn run_app<B: ratatui::backend::Backend>(
                 continue;
             }
 
+            if app.search_mode {
+                match key.code {
+                    KeyCode::Esc => {
+                        app.search_mode = false;
+                        app.search_query.clear();
+                        app.search_active = false;
+                        app.update_filter();
+                        if !app.filtered_entries.is_empty() {
+                            app.list_state.select(Some(0));
+                        }
+                        app.update_diff_if_visible()?;
+                    }
+                    KeyCode::Enter => {
+                        app.search_mode = false;
+                        app.search_active = !app.search_query.is_empty();
+                    }
+                    KeyCode::Backspace => {
+                        app.search_query.pop();
+                        app.update_filter();
+                        app.update_diff_if_visible()?;
+                    }
+                    KeyCode::Char(c) => {
+                        app.search_query.push(c);
+                        app.update_filter();
+                        app.update_diff_if_visible()?;
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+
             if app.show_confirmation {
                 match key.code {
                     KeyCode::Char('y') | KeyCode::Char('Y') => {
@@ -236,7 +328,18 @@ fn run_app<B: ratatui::backend::Backend>(
                 }
             } else {
                 match key.code {
-                    KeyCode::Char('q') | KeyCode::Esc => return Ok(None),
+                    KeyCode::Char('q') => return Ok(None),
+                    KeyCode::Esc => {
+                        if app.search_active {
+                            app.clear_filter();
+                            app.update_diff_if_visible()?;
+                        } else {
+                            return Ok(None);
+                        }
+                    }
+                    KeyCode::Char('/') => {
+                        app.search_mode = true;
+                    }
                     KeyCode::Down | KeyCode::Char('j') => {
                         if app.show_diff && key.modifiers.contains(event::KeyModifiers::SHIFT) {
                             app.scroll_diff_down();
@@ -262,28 +365,28 @@ fn run_app<B: ratatui::backend::Backend>(
                         }
                     }
                     KeyCode::Home => {
-                        if !app.entries.is_empty() {
+                        if !app.filtered_entries.is_empty() {
                             app.list_state.select(Some(0));
                             app.update_diff_if_visible()?;
                         }
                     }
                     KeyCode::End => {
-                        if !app.entries.is_empty() {
-                            let last = app.entries.len() - 1;
+                        if !app.filtered_entries.is_empty() {
+                            let last = app.filtered_entries.len() - 1;
                             app.list_state.select(Some(last));
                             app.update_diff_if_visible()?;
                         }
                     }
                     KeyCode::PageDown => {
-                        if !app.entries.is_empty() {
+                        if !app.filtered_entries.is_empty() {
                             let current = app.list_state.selected().unwrap_or(0);
-                            let next = (current + 10).min(app.entries.len() - 1);
+                            let next = (current + 10).min(app.filtered_entries.len() - 1);
                             app.list_state.select(Some(next));
                             app.update_diff_if_visible()?;
                         }
                     }
                     KeyCode::PageUp => {
-                        if !app.entries.is_empty() {
+                        if !app.filtered_entries.is_empty() {
                             let current = app.list_state.selected().unwrap_or(0);
                             let prev = current.saturating_sub(10);
                             app.list_state.select(Some(prev));
@@ -294,7 +397,9 @@ fn run_app<B: ratatui::backend::Backend>(
                         app.toggle_diff()?;
                     }
                     KeyCode::Enter => {
-                        app.show_confirmation_dialog();
+                        if app.selected_entry_idx().is_some() {
+                            app.show_confirmation_dialog();
+                        }
                     }
                     _ => {}
                 }
@@ -366,11 +471,18 @@ fn ui(f: &mut Frame, app: &mut App) {
 
     // Timeline list
     let selected_idx = app.selected_index();
+    let query_lower = app.search_query.to_lowercase();
+    let query_tokens: Vec<String> = query_lower
+        .split_whitespace()
+        .map(|s| s.to_string())
+        .collect();
+    let highlight_query = (app.search_active || app.search_mode) && !query_tokens.is_empty();
     let items: Vec<ListItem> = app
-        .entries
+        .filtered_entries
         .iter()
         .enumerate()
-        .map(|(i, entry)| {
+        .filter_map(|(i, &entry_idx)| {
+            let entry = app.entries.get(entry_idx)?;
             let is_selected = i == selected_idx;
             let style = if is_selected {
                 Style::default().bg(Color::DarkGray).fg(Color::Yellow).add_modifier(Modifier::BOLD)
@@ -385,14 +497,55 @@ fn ui(f: &mut Frame, app: &mut App) {
                 Style::default().fg(Color::DarkGray)
             };
 
-            ListItem::new(Line::from(vec![
+            let mut spans = vec![
                 Span::styled(prefix, style),
                 Span::styled(&entry.relative_time, time_style),
                 Span::raw("  "),
                 Span::styled(&entry.hash[..7], Style::default().fg(Color::Yellow)),
                 Span::raw("  "),
-                Span::styled(&entry.message, style),
-            ]))
+            ];
+
+            if highlight_query {
+                let msg = &entry.message;
+                let msg_lower = msg.to_lowercase();
+                let highlight_style = Style::default().fg(Color::Red).add_modifier(Modifier::BOLD);
+                // Collect all match ranges from all tokens, then merge overlaps
+                let mut ranges: Vec<(usize, usize)> = Vec::new();
+                for token in &query_tokens {
+                    let mut start = 0;
+                    while let Some(pos) = msg_lower[start..].find(token.as_str()) {
+                        let abs = start + pos;
+                        ranges.push((abs, abs + token.len()));
+                        start = abs + token.len();
+                    }
+                }
+                ranges.sort_by_key(|r| r.0);
+                let mut merged: Vec<(usize, usize)> = Vec::new();
+                for r in ranges {
+                    if let Some(last) = merged.last_mut() {
+                        if r.0 <= last.1 {
+                            last.1 = last.1.max(r.1);
+                            continue;
+                        }
+                    }
+                    merged.push(r);
+                }
+                let mut cursor = 0;
+                for (s, e) in merged {
+                    if s > cursor {
+                        spans.push(Span::styled(msg[cursor..s].to_string(), style));
+                    }
+                    spans.push(Span::styled(msg[s..e].to_string(), highlight_style));
+                    cursor = e;
+                }
+                if cursor < msg.len() {
+                    spans.push(Span::styled(msg[cursor..].to_string(), style));
+                }
+            } else {
+                spans.push(Span::styled(&entry.message, style));
+            }
+
+            Some(ListItem::new(Line::from(spans)))
         })
         .collect();
 
@@ -434,8 +587,10 @@ fn ui(f: &mut Frame, app: &mut App) {
 
     // Footer with preview or confirmation dialog
     if app.show_confirmation {
-        let selected_idx = app.selected_index();
-        let confirm_text = if let Some(entry) = app.entries.get(selected_idx) {
+        let confirm_text = if let Some(entry) = app
+            .selected_entry_idx()
+            .and_then(|i| app.entries.get(i))
+        {
             if app.has_uncommitted_changes {
                 format!(
                     "⚠️  CONFIRM: Reset to {} - {}? This will discard uncommitted changes! [y/N]",
@@ -455,10 +610,36 @@ fn ui(f: &mut Frame, app: &mut App) {
             .style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
             .block(Block::default().borders(Borders::ALL).border_style(Style::default().fg(Color::Red)));
         f.render_widget(footer, chunks[2]);
+    } else if app.search_mode {
+        let match_count = app.filtered_entries.len();
+        let footer_line = Line::from(vec![
+            Span::styled("🔍 Search: ", Style::default().fg(Color::Cyan)),
+            Span::styled(app.search_query.clone(), Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled("█", Style::default().fg(Color::Yellow)),
+            Span::raw(" "),
+            Span::styled(format!("({} matches)", match_count), Style::default().fg(Color::Gray)),
+            Span::raw("  |  "),
+            Span::styled("Enter: apply", Style::default().fg(Color::Green)),
+            Span::raw("  |  "),
+            Span::styled("Esc: cancel", Style::default().fg(Color::Red)),
+        ]);
+        let footer = Paragraph::new(footer_line)
+            .block(Block::default().borders(Borders::ALL).border_style(Style::default().fg(Color::Yellow)));
+        f.render_widget(footer, chunks[2]);
+    } else if app.search_active {
+        let match_count = app.filtered_entries.len();
+        let text = format!(
+            "🔍 Filtered: {} ({} matches) | / to edit | Esc to clear",
+            app.search_query, match_count
+        );
+        let footer = Paragraph::new(text)
+            .style(Style::default().fg(Color::Yellow))
+            .block(Block::default().borders(Borders::ALL).border_style(Style::default().fg(Color::Yellow)));
+        f.render_widget(footer, chunks[2]);
     } else {
-        let selected_idx = app.selected_index();
-        let footer_text = if let Some(entry) = app.entries.get(selected_idx) {
-            format!("📍 Will restore to: {} - {} | Press Space for diff preview", &entry.hash[..7], entry.message)
+        let entry_idx = app.selected_entry_idx().unwrap_or(0);
+        let footer_text = if let Some(entry) = app.entries.get(entry_idx) {
+            format!("📍 Will restore to: {} - {} | / to search | Space for diff", &entry.hash[..7], entry.message)
         } else {
             "No entries found".to_string()
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
     Frame, Terminal,
 };
+use chrono::Local;
 use std::io;
 
 mod git;
@@ -31,6 +32,7 @@ CONTROLS:\n  \
     Home/End    Jump to first/last entry\n  \
     PgUp/PgDn   Jump 10 entries\n  \
     Space       Toggle diff preview\n  \
+    t           Toggle relative/absolute timestamps\n  \
     Enter       Restore to selected commit\n  \
     /           Search/filter commits by message\n  \
     Esc         Clear active filter (or quit if no filter)\n  \
@@ -64,6 +66,7 @@ struct App {
     search_query: String,
     filtered_entries: Vec<usize>,
     search_active: bool,
+    show_absolute_time: bool,
 }
 
 impl App {
@@ -93,6 +96,7 @@ impl App {
             search_query: String::new(),
             filtered_entries,
             search_active: false,
+            show_absolute_time: false,
         })
     }
 
@@ -409,6 +413,9 @@ fn run_app<B: ratatui::backend::Backend>(
                     KeyCode::Char(' ') => {
                         app.toggle_diff()?;
                     }
+                    KeyCode::Char('t') => {
+                        app.show_absolute_time = !app.show_absolute_time;
+                    }
                     KeyCode::Enter => {
                         if app.selected_entry_idx().is_some() {
                             app.show_confirmation_dialog();
@@ -512,7 +519,14 @@ fn ui(f: &mut Frame, app: &mut App) {
 
             let mut spans = vec![
                 Span::styled(prefix, style),
-                Span::styled(&entry.relative_time, time_style),
+                Span::styled(
+                    if app.show_absolute_time {
+                        entry.timestamp.with_timezone(&Local).format("%Y-%m-%d %H:%M:%S").to_string()
+                    } else {
+                        entry.relative_time.clone()
+                    },
+                    time_style,
+                ),
                 Span::raw("  "),
                 Span::styled(&entry.hash[..7], Style::default().fg(Color::Yellow)),
                 Span::raw("  "),

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,8 @@ CONTROLS:\n  \
     ↑/k, ↓/j    Navigate up/down\n  \
     Home/End    Jump to first/last entry\n  \
     PgUp/PgDn   Jump 10 entries\n  \
-    Space       Toggle diff preview\n  \
+    Space       Toggle diff panel\n  \
+    d           Switch between diff summary and full diff\n  \
     t           Toggle relative/absolute timestamps\n  \
     Enter       Restore to selected commit\n  \
     /           Search/filter commits by message\n  \
@@ -58,7 +59,9 @@ struct App {
     list_state: ListState,
     show_confirmation: bool,
     show_diff: bool,
+    show_full_diff: bool,
     diff_content: String,
+    full_diff_content: String,
     diff_scroll_offset: u16,
     diff_visible_height: u16,
     has_uncommitted_changes: bool,
@@ -88,7 +91,9 @@ impl App {
             list_state,
             show_confirmation: false,
             show_diff: false,
+            show_full_diff: false,
             diff_content: String::new(),
+            full_diff_content: String::new(),
             diff_scroll_offset: 0,
             diff_visible_height: 10,
             has_uncommitted_changes,
@@ -149,12 +154,15 @@ impl App {
     }
 
     fn update_diff_if_visible(&mut self) -> Result<()> {
-        if self.show_diff {
-            if let Some(idx) = self.selected_entry_idx() {
-                if let Some(entry) = self.entries.get(idx) {
+        if let Some(idx) = self.selected_entry_idx() {
+            if let Some(entry) = self.entries.get(idx) {
+                if self.show_diff {
                     self.diff_content = self.git_manager.get_diff_stat(&entry.hash)?;
-                    self.diff_scroll_offset = 0;
                 }
+                if self.show_full_diff {
+                    self.full_diff_content = self.git_manager.get_full_diff(&entry.hash)?;
+                }
+                self.diff_scroll_offset = 0;
             }
         }
         Ok(())
@@ -201,9 +209,26 @@ impl App {
     fn toggle_diff(&mut self) -> Result<()> {
         self.show_diff = !self.show_diff;
         if self.show_diff {
+            self.show_full_diff = false;
             if let Some(idx) = self.selected_entry_idx() {
                 if let Some(entry) = self.entries.get(idx) {
                     self.diff_content = self.git_manager.get_diff_stat(&entry.hash)?;
+                }
+            }
+        }
+        self.diff_scroll_offset = 0;
+        Ok(())
+    }
+
+    fn toggle_diff_mode(&mut self) -> Result<()> {
+        if !self.show_diff {
+            return Ok(());
+        }
+        self.show_full_diff = !self.show_full_diff;
+        if self.show_full_diff {
+            if let Some(idx) = self.selected_entry_idx() {
+                if let Some(entry) = self.entries.get(idx) {
+                    self.full_diff_content = self.git_manager.get_full_diff(&entry.hash)?;
                 }
             }
         }
@@ -215,8 +240,16 @@ impl App {
         self.diff_scroll_offset = self.diff_scroll_offset.saturating_sub(1);
     }
 
+    fn active_diff_content(&self) -> &str {
+        if self.show_full_diff {
+            &self.full_diff_content
+        } else {
+            &self.diff_content
+        }
+    }
+
     fn scroll_diff_down(&mut self) {
-        let line_count = self.diff_content.lines().count() as u16;
+        let line_count = self.active_diff_content().lines().count() as u16;
         let max_scroll = line_count.saturating_sub(self.diff_visible_height);
         self.diff_scroll_offset = (self.diff_scroll_offset + 1).min(max_scroll);
     }
@@ -413,6 +446,9 @@ fn run_app<B: ratatui::backend::Backend>(
                     KeyCode::Char(' ') => {
                         app.toggle_diff()?;
                     }
+                    KeyCode::Char('d') => {
+                        app.toggle_diff_mode()?;
+                    }
                     KeyCode::Char('t') => {
                         app.show_absolute_time = !app.show_absolute_time;
                     }
@@ -590,26 +626,61 @@ fn ui(f: &mut Frame, app: &mut App) {
     // Diff preview pane
     if app.show_diff {
         let diff_area = main_chunks[1];
-        app.diff_visible_height = diff_area.height.saturating_sub(2); // Subtract borders
-        
-        let diff_text = if app.diff_content.is_empty() {
-            "Loading diff..."
+        app.diff_visible_height = diff_area.height.saturating_sub(2);
+
+        if app.show_full_diff {
+            let lines: Vec<Line> = if app.full_diff_content.is_empty() {
+                vec![Line::raw("Loading diff...")]
+            } else {
+                app.full_diff_content
+                    .lines()
+                    .map(|line| {
+                        if line.starts_with('+') && !line.starts_with("+++") {
+                            Line::styled(line, Style::default().fg(Color::Green))
+                        } else if line.starts_with('-') && !line.starts_with("---") {
+                            Line::styled(line, Style::default().fg(Color::Red))
+                        } else if line.starts_with("@@") {
+                            Line::styled(line, Style::default().fg(Color::Cyan))
+                        } else if line.starts_with("diff ") || line.starts_with("index ") {
+                            Line::styled(line, Style::default().fg(Color::Yellow))
+                        } else {
+                            Line::raw(line)
+                        }
+                    })
+                    .collect()
+            };
+
+            let diff = Paragraph::new(lines)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(" Full Diff (d: back to summary | Shift+↑↓/J/K: scroll) ")
+                        .border_style(Style::default().fg(Color::Cyan)),
+                )
+                .scroll((app.diff_scroll_offset, 0))
+                .wrap(ratatui::widgets::Wrap { trim: false });
+
+            f.render_widget(diff, diff_area);
         } else {
-            &app.diff_content
-        };
+            let diff_text = if app.diff_content.is_empty() {
+                "Loading diff..."
+            } else {
+                &app.diff_content
+            };
 
-        let diff = Paragraph::new(diff_text)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(" Diff Preview (Shift+↑↓ or J/K to scroll) ")
-                    .border_style(Style::default().fg(Color::Cyan)),
-            )
-            .style(Style::default().fg(Color::White))
-            .scroll((app.diff_scroll_offset, 0))
-            .wrap(ratatui::widgets::Wrap { trim: false });
+            let diff = Paragraph::new(diff_text)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(" Diff Summary (d: full diff | Shift+↑↓/J/K: scroll) ")
+                        .border_style(Style::default().fg(Color::Cyan)),
+                )
+                .style(Style::default().fg(Color::White))
+                .scroll((app.diff_scroll_offset, 0))
+                .wrap(ratatui::widgets::Wrap { trim: false });
 
-        f.render_widget(diff, diff_area);
+            f.render_widget(diff, diff_area);
+        }
     }
 
     // Footer with preview or confirmation dialog


### PR DESCRIPTION
closes #19

added `gg` to jump to top and `G` (shift+g) to jump to bottom. tracks a `last_key_was_g` bool in app state to handle the double-tap. single `g` does nothing on its own, resets on next keypress. also updated the help text.